### PR TITLE
log errors from commons-config

### DIFF
--- a/config/src/main/java/com/opentable/config/util/FileConfigStrategy.java
+++ b/config/src/main/java/com/opentable/config/util/FileConfigStrategy.java
@@ -58,7 +58,7 @@ public class FileConfigStrategy extends AbstractConfigStrategy
                     return config;
                 }
                 catch (ConfigurationException ce) {
-                    LOG.trace("... failed", ce);
+                    LOG.error("... failed", ce);
                 }
             } else {
                 LOG.debug("'{}' does not exist", propertyFile);


### PR DESCRIPTION
As it stands you can't diagnose problems with inclusions, etc, without
stepping through in a debugger.